### PR TITLE
Update node positioning of the arduino and unit test example

### DIFF
--- a/gui/src/examples/graphs/10.arduino.json
+++ b/gui/src/examples/graphs/10.arduino.json
@@ -1,9 +1,9 @@
 {
-  "_objectId": "0x0000c5d5",
+  "_objectId": "0x0000c2d2",
   "annotations": {},
   "nodes": [
     {
-      "_objectId": "0x0000c5d6",
+      "_objectId": "0x0000c573",
       "annotations": {
         "nodeData": {
           "id": "nodeData",
@@ -14,8 +14,8 @@
             "status": "UNDEFINED",
             "type": "editor",
             "position": {
-              "x": 0,
-              "y": -200
+              "x": 12,
+              "y": 12
             },
             "width": 300,
             "height": 200
@@ -26,7 +26,7 @@
       "content": "const int LED_PIN = 13;"
     },
     {
-      "_objectId": "0x0000c5d7",
+      "_objectId": "0x0000c574",
       "annotations": {
         "nodeData": {
           "id": "nodeData",
@@ -49,7 +49,7 @@
       "content": "pinMode(LED_PIN, OUTPUT);"
     },
     {
-      "_objectId": "0x0000c5d8",
+      "_objectId": "0x0000c575",
       "annotations": {
         "nodeData": {
           "id": "nodeData",
@@ -60,8 +60,8 @@
             "status": "UNDEFINED",
             "type": "editor",
             "position": {
-              "x": 1151,
-              "y": 282
+              "x": 1012,
+              "y": 12
             },
             "width": 300,
             "height": 200
@@ -74,14 +74,14 @@
   ],
   "edgeTypes": [
     {
-      "_objectId": "0x0000c5d9",
+      "_objectId": "0x0000c576",
       "annotations": {},
       "id": "sequence",
       "priority": 10,
       "immediate": false
     },
     {
-      "_objectId": "0x0000c5ef",
+      "_objectId": "0x0000c577",
       "annotations": {},
       "id": "arduino",
       "priority": 9,
@@ -90,7 +90,7 @@
   ],
   "edges": [
     {
-      "_objectId": "0x0000c5f0",
+      "_objectId": "0x0000c578",
       "annotations": {
         "edgeData": {
           "id": "edgeData",
@@ -109,7 +109,7 @@
       "targetNode": "Setup"
     },
     {
-      "_objectId": "0x0000c5f1",
+      "_objectId": "0x0000c579",
       "annotations": {
         "edgeData": {
           "id": "edgeData",

--- a/gui/src/examples/graphs/20.test-sum.json
+++ b/gui/src/examples/graphs/20.test-sum.json
@@ -1,263 +1,263 @@
 {
-  "_objectId": "0x0000cd1d",
-  "annotations": {},
-  "nodes": [
-    {
-      "_objectId": "0x0000cd33",
-      "annotations": {
-        "nodeData": {
-          "id": "nodeData",
-          "data": {
-            "content": "function sum(n) {\n    if (n > 0) {\n        return n + sum(n - 1);\n    } else {\n        return 0;\n    }\n}",
-            "label": "Function",
-            "language": "JavaScript",
-            "status": "UNDEFINED",
-            "type": "editor",
-            "position": {
-              "x": 512,
-              "y": 242
+    "_objectId": "0x0000d1b5",
+    "annotations": {},
+    "nodes": [
+        {
+            "_objectId": "0x0000d1b6",
+            "annotations": {
+                "nodeData": {
+                    "id": "nodeData",
+                    "data": {
+                        "content": "function sum(n) {\n    if (n > 0) {\n        return n + sum(n - 1);\n    } else {\n        return 0;\n    }\n}",
+                        "label": "Function",
+                        "language": "JavaScript",
+                        "status": "UNDEFINED",
+                        "type": "editor",
+                        "position": {
+                            "x": 512,
+                            "y": 242
+                        },
+                        "width": 300,
+                        "height": 200
+                    }
+                }
             },
-            "width": 300,
-            "height": 200
-          }
-        }
-      },
-      "id": "Function",
-      "content": "function sum(n) {\n    if (n > 0) {\n        return n + sum(n - 1);\n    } else {\n        return 0;\n    }\n}"
-    },
-    {
-      "_objectId": "0x0000cd34",
-      "annotations": {
-        "nodeData": {
-          "id": "nodeData",
-          "data": {
-            "content": "sum(3) == 6",
-            "label": "Test 1",
-            "language": "JavaScript",
-            "status": "UNDEFINED",
-            "type": "editor",
-            "position": {
-              "x": 12,
-              "y": 472
+            "id": "Function",
+            "content": "function sum(n) {\n    if (n > 0) {\n        return n + sum(n - 1);\n    } else {\n        return 0;\n    }\n}"
+        },
+        {
+            "_objectId": "0x0000d1b7",
+            "annotations": {
+                "nodeData": {
+                    "id": "nodeData",
+                    "data": {
+                        "content": "sum(3) == 6",
+                        "label": "Test 1",
+                        "language": "JavaScript",
+                        "status": "UNDEFINED",
+                        "type": "editor",
+                        "position": {
+                            "x": 10.91208791208794,
+                            "y": 542.7142857142858
+                        },
+                        "width": 300,
+                        "height": 200
+                    }
+                }
             },
-            "width": 300,
-            "height": 200
-          }
-        }
-      },
-      "id": "Test 1",
-      "content": "sum(3) == 6"
-    },
-    {
-      "_objectId": "0x0000cd35",
-      "annotations": {
-        "nodeData": {
-          "id": "nodeData",
-          "data": {
-            "content": "sum(1)",
-            "label": "Test 2",
-            "language": "JavaScript",
-            "status": "UNDEFINED",
-            "type": "editor",
-            "position": {
-              "x": 12,
-              "y": 242
+            "id": "Test 1",
+            "content": "sum(3) == 6"
+        },
+        {
+            "_objectId": "0x0000d1cd",
+            "annotations": {
+                "nodeData": {
+                    "id": "nodeData",
+                    "data": {
+                        "content": "sum(1)",
+                        "label": "Test 2",
+                        "language": "JavaScript",
+                        "status": "UNDEFINED",
+                        "type": "editor",
+                        "position": {
+                            "x": 12,
+                            "y": 242
+                        },
+                        "width": 300,
+                        "height": 200
+                    }
+                }
             },
-            "width": 300,
-            "height": 200
-          }
-        }
-      },
-      "id": "Test 2",
-      "content": "sum(1)"
-    },
-    {
-      "_objectId": "0x0000cd36",
-      "annotations": {
-        "nodeData": {
-          "id": "nodeData",
-          "data": {
-            "content": "sum(-1) == -1",
-            "label": "Test 3",
-            "language": "JavaScript",
-            "status": "UNDEFINED",
-            "type": "editor",
-            "position": {
-              "x": 12,
-              "y": 12
+            "id": "Test 2",
+            "content": "sum(1)"
+        },
+        {
+            "_objectId": "0x0000d1ce",
+            "annotations": {
+                "nodeData": {
+                    "id": "nodeData",
+                    "data": {
+                        "content": "sum(-1) == -1",
+                        "label": "Test 3",
+                        "language": "JavaScript",
+                        "status": "UNDEFINED",
+                        "type": "editor",
+                        "position": {
+                            "x": 6.56043956043959,
+                            "y": -57.626373626373635
+                        },
+                        "width": 300,
+                        "height": 200
+                    }
+                }
             },
-            "width": 300,
-            "height": 200
-          }
-        }
-      },
-      "id": "Test 3",
-      "content": "sum(-1) == -1"
-    },
-    {
-      "_objectId": "0x0000cd37",
-      "annotations": {
-        "nodeData": {
-          "id": "nodeData",
-          "data": {
-            "content": "sum(3) + sum(1);",
-            "label": "Usage",
-            "language": "JavaScript",
-            "status": "UNDEFINED",
-            "type": "editor",
-            "position": {
-              "x": 1012,
-              "y": 242
+            "id": "Test 3",
+            "content": "sum(-1) == -1"
+        },
+        {
+            "_objectId": "0x0000d1cf",
+            "annotations": {
+                "nodeData": {
+                    "id": "nodeData",
+                    "data": {
+                        "content": "sum(3) + sum(1);",
+                        "label": "Usage",
+                        "language": "JavaScript",
+                        "status": "UNDEFINED",
+                        "type": "editor",
+                        "position": {
+                            "x": 1012,
+                            "y": 242
+                        },
+                        "width": 300,
+                        "height": 200
+                    }
+                }
             },
-            "width": 300,
-            "height": 200
-          }
-        }
-      },
-      "id": "Usage",
-      "content": "sum(3) + sum(1);"
-    },
-    {
-      "_objectId": "0x0000cd38",
-      "annotations": {
-        "nodeData": {
-          "id": "nodeData",
-          "data": {
-            "label": "Result",
-            "language": "PlainText",
-            "status": "UNDEFINED",
-            "type": "editor",
-            "position": {
-              "x": 1512,
-              "y": 242
+            "id": "Usage",
+            "content": "sum(3) + sum(1);"
+        },
+        {
+            "_objectId": "0x0000d1d0",
+            "annotations": {
+                "nodeData": {
+                    "id": "nodeData",
+                    "data": {
+                        "label": "Result",
+                        "language": "PlainText",
+                        "status": "UNDEFINED",
+                        "type": "editor",
+                        "position": {
+                            "x": 1512,
+                            "y": 242
+                        },
+                        "width": 300,
+                        "height": 200
+                    }
+                }
             },
-            "width": 300,
-            "height": 200
-          }
+            "id": "Result",
+            "content": ""
         }
-      },
-      "id": "Result",
-      "content": ""
-    }
-  ],
-  "edgeTypes": [
-    {
-      "_objectId": "0x0000cd39",
-      "annotations": {},
-      "id": "test",
-      "priority": 0,
-      "immediate": true
-    },
-    {
-      "_objectId": "0x0000cd3a",
-      "annotations": {},
-      "id": "sequence",
-      "priority": 2,
-      "immediate": false
-    },
-    {
-      "_objectId": "0x0000cd3b",
-      "annotations": {},
-      "id": "execute",
-      "priority": 1,
-      "immediate": false
-    }
-  ],
-  "edges": [
-    {
-      "_objectId": "0x0000cd3c",
-      "annotations": {
-        "edgeData": {
-          "id": "edgeData",
-          "data": {
-            "type": "empty",
-            "sourceHandle": "right",
-            "targetHandle": "left",
-            "edgePathStyle": "Smooth",
+    ],
+    "edgeTypes": [
+        {
+            "_objectId": "0x0000d1d1",
+            "annotations": {},
+            "id": "test",
             "priority": 0,
             "immediate": true
-          }
-        }
-      },
-      "edgeType": "test",
-      "sourceNode": "Test 1",
-      "targetNode": "Function"
-    },
-    {
-      "_objectId": "0x0000cd52",
-      "annotations": {
-        "edgeData": {
-          "id": "edgeData",
-          "data": {
-            "type": "empty",
-            "sourceHandle": "right",
-            "targetHandle": "left",
-            "edgePathStyle": "Smooth",
-            "priority": 0,
-            "immediate": true
-          }
-        }
-      },
-      "edgeType": "test",
-      "sourceNode": "Test 2",
-      "targetNode": "Function"
-    },
-    {
-      "_objectId": "0x0000cd53",
-      "annotations": {
-        "edgeData": {
-          "id": "edgeData",
-          "data": {
-            "type": "empty",
-            "sourceHandle": "right",
-            "targetHandle": "left",
-            "edgePathStyle": "Smooth",
-            "priority": 0,
-            "immediate": true
-          }
-        }
-      },
-      "edgeType": "test",
-      "sourceNode": "Test 3",
-      "targetNode": "Function"
-    },
-    {
-      "_objectId": "0x0000cd54",
-      "annotations": {
-        "edgeData": {
-          "id": "edgeData",
-          "data": {
-            "type": "empty",
-            "sourceHandle": "right",
-            "targetHandle": "left",
-            "edgePathStyle": "Smooth",
+        },
+        {
+            "_objectId": "0x0000d1d2",
+            "annotations": {},
+            "id": "sequence",
             "priority": 2,
             "immediate": false
-          }
-        }
-      },
-      "edgeType": "sequence",
-      "sourceNode": "Function",
-      "targetNode": "Usage"
-    },
-    {
-      "_objectId": "0x0000cd55",
-      "annotations": {
-        "edgeData": {
-          "id": "edgeData",
-          "data": {
-            "type": "empty",
-            "sourceHandle": "right",
-            "targetHandle": "left",
-            "edgePathStyle": "Smooth",
+        },
+        {
+            "_objectId": "0x0000d1d3",
+            "annotations": {},
+            "id": "execute",
             "priority": 1,
             "immediate": false
-          }
         }
-      },
-      "edgeType": "execute",
-      "sourceNode": "Usage",
-      "targetNode": "Result"
-    }
-  ]
+    ],
+    "edges": [
+        {
+            "_objectId": "0x0000d1d4",
+            "annotations": {
+                "edgeData": {
+                    "id": "edgeData",
+                    "data": {
+                        "type": "empty",
+                        "sourceHandle": "right",
+                        "targetHandle": "left",
+                        "edgePathStyle": "Smooth",
+                        "priority": 0,
+                        "immediate": true
+                    }
+                }
+            },
+            "edgeType": "test",
+            "sourceNode": "Test 1",
+            "targetNode": "Function"
+        },
+        {
+            "_objectId": "0x0000d1d5",
+            "annotations": {
+                "edgeData": {
+                    "id": "edgeData",
+                    "data": {
+                        "type": "empty",
+                        "sourceHandle": "right",
+                        "targetHandle": "left",
+                        "edgePathStyle": "Smooth",
+                        "priority": 0,
+                        "immediate": true
+                    }
+                }
+            },
+            "edgeType": "test",
+            "sourceNode": "Test 2",
+            "targetNode": "Function"
+        },
+        {
+            "_objectId": "0x0000d1d6",
+            "annotations": {
+                "edgeData": {
+                    "id": "edgeData",
+                    "data": {
+                        "type": "empty",
+                        "sourceHandle": "right",
+                        "targetHandle": "left",
+                        "edgePathStyle": "Smooth",
+                        "priority": 0,
+                        "immediate": true
+                    }
+                }
+            },
+            "edgeType": "test",
+            "sourceNode": "Test 3",
+            "targetNode": "Function"
+        },
+        {
+            "_objectId": "0x0000d477",
+            "annotations": {
+                "edgeData": {
+                    "id": "edgeData",
+                    "data": {
+                        "type": "empty",
+                        "sourceHandle": "right",
+                        "targetHandle": "left",
+                        "edgePathStyle": "Smooth",
+                        "priority": 2,
+                        "immediate": false
+                    }
+                }
+            },
+            "edgeType": "sequence",
+            "sourceNode": "Function",
+            "targetNode": "Usage"
+        },
+        {
+            "_objectId": "0x0000d478",
+            "annotations": {
+                "edgeData": {
+                    "id": "edgeData",
+                    "data": {
+                        "type": "empty",
+                        "sourceHandle": "right",
+                        "targetHandle": "left",
+                        "edgePathStyle": "Smooth",
+                        "priority": 1,
+                        "immediate": false
+                    }
+                }
+            },
+            "edgeType": "execute",
+            "sourceNode": "Usage",
+            "targetNode": "Result"
+        }
+    ]
 }


### PR DESCRIPTION
Updated node positions in the arduino and unit test example. Please check.
However, this issue spawned #106. RunImmediate, for example, performs an own layout run before rendering. The render functionality should be refactored to avoid duplicated code and complicated store interactions.